### PR TITLE
Fix issues with get/extract schema info and get/extract models and categories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,4 +9,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @wilmaier @androidbalasu @debasis-mondal
+*       @wilmaier @prashanth-anantharam @debasis-mondal

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,4 +9,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @wilmaier @prashanth-anantharam @debasis-mondal
+*       @wilmaier @prashanth-ananth @debasis-mondal

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,9 @@
 # @itwin/clash-detection-client
 
+## 0.2.1
+
+- Fix issues with get/extract schema info and get/extract models and categories
+
 ## 0.2.0
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ The __@itwin/clash-detection-client__ package consists of thin wrapper functions
 - [EntityListIterator](./src/base/iterators/EntityListIterator.ts#L6)
 - [MinimalSuppressionRule](./src/base/interfaces/apiEntities/SuppressionRuleInterfaces.ts#L25)
 - [MinimalRun](./src/base/interfaces/apiEntities/RunInterfaces.ts#L15)
-- [ModelsAndCategories](./src/base/interfaces/apiEntities/IModelInterfaces.ts#L88)
+- [ResponseFromGetModelsAndCategories](./src/base/interfaces/apiEntities/IModelInterfaces.ts#L78)
 - [ResponseFromGetResult](./src/base/interfaces/apiEntities/ResultInterfaces.ts#L47)
+- [ResponseFromGetSchemaInfo](./src/base/interfaces/apiEntities/IModelInterfaces.ts#L54)
 - [Run](./src/base/interfaces/apiEntities/TestInterfaces.ts#L102)
 - [RunDetails](./src/base/interfaces/apiEntities/RunInterfaces.ts#L25)
-- [SchemaInfo](./src/base/interfaces/apiEntities/IModelInterfaces.ts#L54)
 - [SuppressionRule](./src/base/interfaces/apiEntities/SuppressionRuleInterfaces.ts#L76)
 - [SuppressionRuleDetails](./src/base/interfaces/apiEntities/SuppressionRuleInterfaces.ts#L35)
 - [SuppressionRuleTemplate](./src/base/interfaces/apiEntities/TemplateInterfaces.ts#L7)
@@ -29,9 +29,10 @@ The __@itwin/clash-detection-client__ package consists of thin wrapper functions
 
 ## Key methods
 - [`client.imodel.extractModelsAndCategories(params: ParamsToExtractModelsAndCategories): Promise<void>`](#extract-models-and-categories)
-- [`client.imodel.getModelsAndCategories(params: ParamsToGetModelsAndCategories): Promise<ModelsAndCategories>`](#get-models-and-categories)
+- [`client.imodel.getModelsAndCategories(params: ParamsToGetModelsAndCategories): Promise<ResponseFromGetModelsAndCategories>`](#get-models-and-categories)
 - [`client.imodel.extractSchemaInfo(params: ParamsToExtractSchemaInfo): Promise<void>`](#extract-schema-information)
-- [`client.imodel.getSchemaInfo(params: ParamsToGetSchemaInfo): Promise<SchemaInfo>`](#get-schema-information)
+- [`client.imodel.getSchemaInfo(params: ParamsToGetSchemaInfo): Promise<ResponseFromGetSchemaInfo>`]
+(#get-schema-information)
 - [`client.templates.getList(params: ParamsToGetTemplateList): EntityListIterator<RuleTemplate>`](#get-all-clash-detection-suppression-rule-templates)
 - [`client.rules.create(params: ParamsToCreateRule): Promise<SuppressionRule>`](#create-clash-detection-suppression-rule)
 - [`client.rules.update(params: ParamsToUpdateRule): Promise<SuppressionRule>`](#update-clash-detection-suppression-rule)
@@ -478,7 +479,7 @@ async function extractModelsAndCategories(accessToken: string, projectId: string
 
 ### Get models and categories
 ```typescript
-import { ClashDetectionClient, ModelsAndCategories, ParamsToGetModelsAndCategories } from "@itwin/clash-detection-client";
+import { ClashDetectionClient, ParamsToGetModelsAndCategories, ResponseFromGetModelsAndCategories } from "@itwin/clash-detection-client";
 /** Function that gets the list of models and categories in an iModel and prints the extraction status and count of models and categories. */
 async function getModelsAndCategories(accessToken: string, projectId: string, iModelId: string): Promise<void> {
   const clashDetectionClient: ClashDetectionClient = new ClashDetectionClient();
@@ -488,7 +489,7 @@ async function getModelsAndCategories(accessToken: string, projectId: string, iM
       projectId,
     },
   };
-  const modelsAndCategories: ModelsAndCategories = await clashDetectionClient.imodel.getModelsAndCategories(params);
+  const modelsAndCategories: ResponseFromGetModelsAndCategories = await clashDetectionClient.imodel.getModelsAndCategories(params);
   console.log('Status: ${modelsAndCategories.status}, model count: ${modelsAndCategories.models.length}, category count: ${modelsAndCategories.categories.length}');
 }
 ```
@@ -511,7 +512,7 @@ async function extractSchemaInfo(accessToken: string, projectId: string, iModelI
 ```
 ### Get schema information
 ```typescript
-import { ClashDetectionClient, ParamsToGetSchemaInfo, SchemaInfo } from "@itwin/clash-detection-client";
+import { ClashDetectionClient, ParamsToGetSchemaInfo, ResponseFromGetSchemaInfo } from "@itwin/clash-detection-client";
 /** Function that gets the iModel schema information and prints the extraction status and count of schemas. */
 async function getSchemaInfo(accessToken: string, projectId: string, iModelId: string): Promise<void> {
   const clashDetectionClient: ClashDetectionClient = new ClashDetectionClient();
@@ -521,7 +522,7 @@ async function getSchemaInfo(accessToken: string, projectId: string, iModelId: s
       projectId,
     },
   };
-  const schemaInfo: SchemaInfo = await clashDetectionClient.imodel.getSchemaInfo(params);
+  const schemaInfo: ResponseFromGetSchemaInfo = await clashDetectionClient.imodel.getSchemaInfo(params);
   console.log('Status: ${schemaInfo.status}, schema count: ${schemaInfo.schema.length}');
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/clash-detection-client",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Clash Detection client for the iTwin platform",
   "main": "lib/cjs/clash-detection-client.js",
   "module": "lib/esm/clash-detection-client.js",

--- a/src/base/interfaces/apiEntities/IModelInterfaces.ts
+++ b/src/base/interfaces/apiEntities/IModelInterfaces.ts
@@ -51,17 +51,12 @@ export interface Schema {
   entityClass: EntityClass[];
 }
 
-/** Extracted schema info. */
-export interface SchemaInfo {
+/** Get Schema Info API response. */
+export interface ResponseFromGetSchemaInfo {
   /** The status of the schema info extraction. One of 'available', 'unavailable'. */
   status: string;
   /* Array of schemas in iModel */
   schema: Schema[];
-}
-
-/** Get Schema Info API response. */
-export interface ResponseFromGetSchemaInfo {
-  schemaInfo: SchemaInfo;
 }
 
 /** Model. */
@@ -80,17 +75,12 @@ export interface Category {
   displayName: string;
 }
 
-/** Extracted models and categories. */
-export interface ModelsAndCategories {
+/** Get Models and Categories API response. */
+export interface ResponseFromGetModelsAndCategories {
   /** The status of the models and categories extraction. One of 'available', 'unavailable'. */
   status: string;
   /* Array of models in iModel */
   models: Model[];
   /* Array of categories in iModel */
   categories: Category[];
-}
-
-/** Get Models and Categories API response. */
-export interface ResponseFromGetModelsAndCategories {
-  modelsAndCategories: ModelsAndCategories;
 }

--- a/src/operations/ClashDetectionApiUrlFormatter.ts
+++ b/src/operations/ClashDetectionApiUrlFormatter.ts
@@ -81,11 +81,11 @@ export class ClashDetectionApiUrlFormatter {
   }
 
   public getSchemaInfoUrl(params: { iModelId: string, urlParams?: ParamsToGetSchemaInfoUrl }): string {
-    return `${this.baseUrl}/schema/imodels/${params.iModelId}${this.formQueryString({ ...params.urlParams })}`;
+    return `${this.baseUrl}/schemas/imodels/${params.iModelId}${this.formQueryString({ ...params.urlParams })}`;
   }
 
   public extractSchemaInfoUrl(params: { iModelId: string }): string {
-    return `${this.baseUrl}/schema/imodels/${params.iModelId}}`;
+    return `${this.baseUrl}/schemas/imodels/${params.iModelId}`;
   }
 
   public getModelsAndCategoriesUrl(params: { iModelId: string, urlParams?: ParamsToGetModelsAndCategoriesUrl }): string {
@@ -93,7 +93,7 @@ export class ClashDetectionApiUrlFormatter {
   }
 
   public extractModelsAndCategoriesUrl(params: { iModelId: string }): string {
-    return `${this.baseUrl}/modelsAndCategories/imodels/${params.iModelId}}`;
+    return `${this.baseUrl}/modelsAndCategories/imodels/${params.iModelId}`;
   }
 
   protected formQueryString(urlParameters: Dictionary<UrlParameterValue> | undefined): string {

--- a/src/operations/imodel/IModelOperations.ts
+++ b/src/operations/imodel/IModelOperations.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { OperationUtils } from "../OperationUtils";
 import { OperationsBase } from "../../base/OperationsBase";
-import type { ModelsAndCategories, ResponseFromGetModelsAndCategories, ResponseFromGetSchemaInfo, SchemaInfo } from "../../base/interfaces/apiEntities/IModelInterfaces";
+import type { ResponseFromGetModelsAndCategories, ResponseFromGetSchemaInfo } from "../../base/interfaces/apiEntities/IModelInterfaces";
 import type { OperationOptions } from "../OperationOptions";
 import type { ParamsToExtractModelsAndCategories, ParamsToExtractSchemaInfo, ParamsToGetModelsAndCategories, ParamsToGetSchemaInfo } from "./IModelOperationParams";
 
@@ -20,9 +20,9 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
    * Wraps the {@link https://developer.bentley.com/apis/clash-detection/operations/get-schema-info/
    * Get schema info} operation from Clash Detection API.
    * @param {ParamsToGetSchemaInfo} params parameters for this operation. See {@link ParamsToGetSchemaInfo}.
-   * @returns {Promise<SchemaInfo>} schema info for specified iModel and project id. See {@link SchemaInfo}.
+   * @returns {Promise<ResponseFromGetSchemaInfo>} schema info for specified iModel and project id. See {@link ResponseFromGetSchemaInfo}.
    */
-  public async getSchemaInfo(params: ParamsToGetSchemaInfo): Promise<SchemaInfo> {
+  public async getSchemaInfo(params: ParamsToGetSchemaInfo): Promise<ResponseFromGetSchemaInfo> {
     const { accessToken, iModelId } = params;
     OperationUtils.ensureAccessTokenProvided(accessToken, this._options.accessTokenCallback);
     const response = await this.sendGetRequest<ResponseFromGetSchemaInfo>({
@@ -30,11 +30,12 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
       accessToken: accessToken ?? await this._options.accessTokenCallback!(),
       url: this._options.urlFormatter.getSchemaInfoUrl({ iModelId, urlParams: params.urlParams }),
     });
-    return response.schemaInfo;
+    return response;
   }
 
   /**
-   * Extracts schema info. Wraps the {@link https://developer.bentley.com/apis/clash-detection/operations/extract-schema-info/
+   * Extracts schema info. Required once per iModel before calling getSchemaInfo(). Extraction is only performed if needed.
+   * Wraps the {@link https://developer.bentley.com/apis/clash-detection/operations/extract-schema-info/
    * Extract schema info} operation from Clash Detection API.
    * @param {ParamsToExtractSchemaInfo} params parameters for this operation. See {@link ParamsToExtractSchemaInfo}.
    * @returns {Promise<void>}.
@@ -60,7 +61,7 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
    * @param {ParamsToGetModelsAndCategories} params parameters for this operation. See {@link ParamsToGetModelsAndCategories}.
    * @returns {Promise<ModelsAndCategories>} models and categories for specified iModel and project id. See {@link ModelsAndCategories}.
    */
-  public async getModelsAndCategories(params: ParamsToGetModelsAndCategories): Promise<ModelsAndCategories> {
+  public async getModelsAndCategories(params: ParamsToGetModelsAndCategories): Promise<ResponseFromGetModelsAndCategories> {
     const { accessToken, iModelId } = params;
     OperationUtils.ensureAccessTokenProvided(accessToken, this._options.accessTokenCallback);
     const response = await this.sendGetRequest<ResponseFromGetModelsAndCategories>({
@@ -68,7 +69,7 @@ export class IModelOperations<TOptions extends OperationOptions> extends Operati
       accessToken: accessToken ?? await this._options.accessTokenCallback!(),
       url: this._options.urlFormatter.getModelsAndCategoriesUrl({ iModelId, urlParams: params.urlParams }),
     });
-    return response.modelsAndCategories;
+    return response;
   }
 
   /**


### PR DESCRIPTION
The interfaces for responses from get schema info and get models and categories are not correct.
The API URLs are incorrect for get and extract schema info and extract models and categories.